### PR TITLE
docs: fix href to configuration chapter in hubble data api chapter

### DIFF
--- a/docs/pwa/backends/hubbleDataApi.md
+++ b/docs/pwa/backends/hubbleDataApi.md
@@ -66,7 +66,7 @@ API_ENDPOINT_AUTH = 'oauth/token'
 
 ::: warning
 Client-seitig erlaubte Keys müssen in der __`~/nuxt.config.js`__ auf die Whitelist gesetzt werden,
-damit diese zur Verfügung stehen. Zur korrekten Einrichtung sollte der Abschnitt [Konfiguration](configuration.md) referenziert werden.
+damit diese zur Verfügung stehen. Zur korrekten Einrichtung sollte der Abschnitt [Konfiguration](../configuration.md) referenziert werden.
 :::
 
 


### PR DESCRIPTION
While browsing the documentation I noticed a broken link in "Hubble Data API" section "[Verwendung der hubble API und des Auth Token](https://docs.hubblecommerce.io/pwa/backends/hubbleDataApi.html#auth-token-und-hubble-api-als-proxy)".


![image](https://user-images.githubusercontent.com/8781699/116936285-e647b480-ac67-11eb-8f49-30d7d7b09934.png)

Here's a quick fix made with :heart: