### PR TITLE
docs: fix generate components doc and update dependencies

### DIFF
--- a/generateComponentLib.js
+++ b/generateComponentLib.js
@@ -21,13 +21,23 @@ const listAllFilesAndDirs = dir => globby(`${dir}/**/*`);
     await fs.mkdirSync(targetDir);
 
     // Generate files from source directory
-    const files = await listAllFilesAndDirs(sourceDir);
-    files.forEach(file => {
-        Vuedoc.md({filename: file})
-            .then((document) => {
+    const files = await listAllFilesAndDirs(sourceDir)
+
+    // for loop will ensure await processing
+    // of each individual file will work as aspected.
+    // This will improve the review process when one
+    // parsing will fail you are able to locate the failing file
+    // by looking at the latest console.debug() message.
+    for (const file of files) {
+        // print currently processed filename to enhance debugging
+        console.debug(`Processing '${file}'`)
+        // await each processing ensures the process stops
+        // at the failing file which will make debugging easier
+        await Vuedoc.md({filenames: [file]})
+            .then(document => {
                 const readmeFileName = path.parse(file).base.replace('.vue', '.md')
                 fs.writeFileSync(`${targetDir}/${readmeFileName}`, document);
             })
             .catch((err) => console.error(err));
-    })
+    }
 })();

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "doc": "docs"
   },
   "dependencies": {
-    "@hubblecommerce/hubble": "^1.1.0",
-    "@vuedoc/md": "^3.0.0-beta2",
-    "@vuedoc/parser": "^3.0.0-beta4",
+    "@hubblecommerce/hubble": "^1.1.7",
+    "@vuedoc/md": "^3.2.0",
+    "@vuedoc/parser": "^3.3.0",
     "fs-extra": "^9.0.1",
     "globby": "^11.0.1"
   },


### PR DESCRIPTION
As you can see in https://github.com/hubblecommerce/hubble-docs/pull/1 executing
```
node generateComponentLib
```
as defined in `docs:dev` and `docs:build` (within [`package.json`](https://github.com/hubblecommerce/hubble-docs/blob/65ed35eee2de85fd68937cfb043b7cd017a991d0/package.json#L20)) will fail. See this [build log](https://app.netlify.com/sites/eager-jones-4cc84f/deploys/60906f0c916b250007fa1494#L127-L141).

While investigating I modified the `generateComponentLib.js` to enhance debugging. In result I was able to drill down the problem within `node_modules/@hubblecommerce/hubble/core/components/utils/MaterialRipple.vue`:

```
[...]
Processing 'node_modules/@hubblecommerce/hubble/core/components/utils/Loader.vue'
Processing 'node_modules/@hubblecommerce/hubble/core/components/utils/MaterialRipple.vue'
X:\xxx\node_modules\@vuedoc\parser\lib\parser\AbstractParser.js:210
    if (key in this.scope && this.scope[key] && this.scope[key].type !== value.type) {
                                                                               ^

TypeError: Cannot read property 'type' of undefined
    at EventParser.setScopeValue (X:\xxx\node_modules\@vuedoc\parser\lib\parser\AbstractParser.js:210:80)
[...]
```

Further research resulted in the conclusion that [two lines of code](https://github.com/hubblecommerce/hubble-frontend-pwa/blob/212f81bb78626d4e79bdc1cc40a55c79ae73fd4b/%40hubblecommerce/hubble/core/components/utils/MaterialRipple.vue#L103-L104) within the mentioned file cause the vue/parser to fail:
```javascript
this.top = top;
this.left = left;
```

In fact this is a bug by [vuedoc/parser](https://github.com/vuedoc/parser). I created a patch (https://github.com/vuedoc/parser/pull/30) to resolve this issue. Once it's applied you will be able to execute the `node generateComponentLib` command as expected.

I also updated the dependencies of `hubblecommerce/hubble`, `vuedoc/md` and `vuedoc/parser`